### PR TITLE
Temporary fix for broken zlib URL.

### DIFF
--- a/thirdParty/requirements.txt
+++ b/thirdParty/requirements.txt
@@ -1,1 +1,2 @@
+zlib,http://zlib.net/fossils/zlib-1.2.11.tar.gz
 statgen/savvy@5cf11170e5d


### PR DESCRIPTION
This issue is fixed in latest version of Savvy, but I didn't want to change Savvy version without testing. This is a workaround that uses that same version of Savvy and Zlib.